### PR TITLE
Add example run for gldapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,14 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/gldcore/solvers)
 add_subdirectory(${CMAKE_SOURCE_DIR}/gldcore/link/engine)
 add_subdirectory(gldcore)
 
+# Add test_gldapi executable
+add_executable(test_gldapi gldcore/test_gldapi.cpp)
+target_link_libraries(test_gldapi PRIVATE gldapi ${DL_LIB} ${JSONCPP_LIB} ${SUPERLU_LIB} Threads::Threads)
+set_target_properties(test_gldapi PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin
+)
+
+
 get_target_property(GLD_COMPILE_OPTIONS gridlabd COMPILE_OPTIONS)
 string(JOIN " " GLD_COMPILE_OPTIONS ${GLD_COMPILE_OPTIONS})
 configure_file(cmake/gridlabd.sh.in ${CMAKE_CURRENT_BINARY_DIR}/script/${GLD_PACKAGE}.sh @ONLY)

--- a/gldcore/gldapi.cpp
+++ b/gldcore/gldapi.cpp
@@ -201,7 +201,7 @@ GLDErrorCode GridLabD::setup_before_load(int argc, char* argv[]) {
 }
 
 // Load a GLM file
-GLDErrorCode GridLabD::setup_after_load(const std::string& filepath) {
+GLDErrorCode GridLabD::setup_after_load() {
    
 
     /* initialize scheduler */

--- a/gldcore/gldapi.h
+++ b/gldcore/gldapi.h
@@ -63,7 +63,7 @@ public:
     GLDErrorCode setup_before_load(int argc, char* argv[]);
 
     // Setup GLD and return an error code
-    GLDErrorCode setup_after_load(const std::string& filepath) ;
+    GLDErrorCode setup_after_load() ;
 
     // Get the GLM data based on a query
     GLDErrorCode get_glm_data(const std::string& query, GLDData& result);

--- a/gldcore/test_gldapi.cpp
+++ b/gldcore/test_gldapi.cpp
@@ -1,0 +1,42 @@
+#include "gldapi.h"
+#include <iostream>
+#include <vector>
+#include <string>
+
+int main(int argc, char* argv[]) {
+    // Dummy command line arguments
+    std::vector<const char*> args = {"gridlabd", "test_commercial_const_air_temp.glm", "--verbose"};
+    int test_argc = static_cast<int>(args.size());
+    char* test_argv[] = { const_cast<char*>(args[0]), const_cast<char*>(args[1]), const_cast<char*>(args[2])};
+
+    // Instantiate GridLabD
+    GridLabD gld(test_argc, test_argv);
+
+    // Test set_config_file
+    gld.set_config_file("config.cfg");
+    
+    // Test load_glm
+    gld.load_glm("test_commercial_const_air_temp.glm", test_argc, test_argv);
+
+    gld.setup_after_load();
+
+    // Test run
+    double sim_time = 0.0;
+    gld.run(0.0, 10.0, sim_time, test_argc, test_argv);
+
+    // Test step
+    // gld.step(sim_time);
+
+    // Test get_time
+    // std::string current_time;
+    // gld.get_time(current_time);
+    // std::cout << "Current simulation time: " << current_time << std::endl;
+
+    // Test set_time
+    // gld.set_time("2025-06-12T12:00:00");
+
+    // Test exit_gld
+    gld.exit_gld("test.glm");
+
+    return 0;
+}


### PR DESCRIPTION
Here's the launch.json configuration I used to debug: 

        {
            "name": "Debug test_gldapi",
            "type": "cppdbg",
            "request": "launch",
            "program": "${workspaceFolder}/build/bin/test_gldapi",
            "args": ["test_commercial_const_air_temp", "--verbose"],
            "stopAtEntry": false,
            "cwd": "${workspaceFolder}/commercial/autotest",
            "environment": [
                { "name": "PATH", "value": "/mnt/c/dev/gridlab-d_fork/build/bin:${env:PATH}" }
            ],
            "externalConsole": false,
            "MIMode": "gdb",
            "miDebuggerPath": "/usr/bin/gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for GDB",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                },
                {
                    "description": "Load .gdbinit commands",
                    "text": "source /mnt/c/dev/gridlab-d_fork/.gdbinit",
                    "ignoreFailures": true
                }
            ]
        }